### PR TITLE
Add ability to map source paths to module names.

### DIFF
--- a/client/commonjs_bridge.js
+++ b/client/commonjs_bridge.js
@@ -11,7 +11,9 @@
 
 
     function require(requiringFile, dependency) {
-        dependency = normalizePath(requiringFile, dependency);
+        if (!window.__cjs_module__[dependency]) {
+          dependency = normalizePath(requiringFile, dependency);
+        }
 
         // find module
         var moduleFn = window.__cjs_module__[dependency];
@@ -34,6 +36,10 @@
     };
 
     function normalizePath(basePath, relativePath) {
+        if (window.__cjs_map__ && window.__cjs_map__[relativePath]) {
+          relativePath = window.__cjs_map__[relativePath];
+        }
+
         if (isFullPath(relativePath)) return relativePath;
         if (!isFullPath(basePath)) throw new Error("basePath should be full path, but was [" + basePath + "]");
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -14,19 +14,38 @@ var initCommonJS = function(/* config.files */ files) {
 };
 
 
-var createPreprocesor = function(logger) {
+var createPreprocessor = function(config, logger) {
   var log = logger.create('preprocessor.commonjs');
+
+  var resolvedMap = {};
+  if (config.map) {
+    var file;
+    for (file in config.map) {
+      if (config.map.hasOwnProperty(file)) {
+        resolvedMap[path.resolve(file)] = config.map[file];
+      }
+    }
+  }
 
   return function(content, file, done) {
     if (file.originalPath === BRIDGE_FILE_PATH) {
       return done(content);
     }
 
+    var output = "";
+    var path = file.originalPath;
     log.debug('Processing "%s".', file.originalPath);
+    if (resolvedMap[path]) {
+      path = resolvedMap[path];
+      output =
+        'window.__cjs_map__ = window.__cjs_map__ || {};' +
+        'window.__cjs_map__["' + path + '"] = "' + file.originalPath + '";';
+      log.debug('Mapping "%s" to "%s".', file.originalPath, path);
+    }
 
-    var output =
+    output +=
       'window.__cjs_module__ = window.__cjs_module__ || {};' +
-      'window.__cjs_module__["' + file.originalPath + '"] = function(require, module, exports) {' +
+      'window.__cjs_module__["' + path + '"] = function(require, module, exports) {' +
         content +
       '}';
 
@@ -34,9 +53,10 @@ var createPreprocesor = function(logger) {
   };
 };
 
+createPreprocessor.$inject = ['config.commonjs', 'logger'];
 
 // PUBLISH DI MODULE
 module.exports = {
   'framework:commonjs': ['factory', initCommonJS],
-  'preprocessor:commonjs': ['factory', createPreprocesor]
+  'preprocessor:commonjs': ['factory', createPreprocessor]
 };


### PR DESCRIPTION
Using browserify with express allows me to require npm modules directly from the node_modules path, e.g. require("bean"). karma-commonjs unfortunately resolves "bean" to a relative path to the source file which of course doesn't work, as that would be something like "../../node_modules/bean/bean".

This patch adds a "commonjs" config with one property "map" that allows to map any source file to a different module name. Example karma.conf.js snippet:

```
    [...]
    files : [
      {pattern: 'node_modules/bean/bean.js',      watched: false},
      {pattern: 'node_modules/domready/ready.js', watched: false},
      'browser/lib/*.js',
      'browser/lib/**/*.js',
      'browser/test/*-test.js',
      'browser/test/**/*-test.js'
    ],
    preprocessors : {
      'node_modules/bean/bean.js'      : ['commonjs'],
      'node_modules/domready/ready.js' : ['commonjs'],
      'browser/**/*.js'                : ['commonjs']
    },
    commonjs : {
      map : {
        'node_modules/bean/bean.js'      : 'bean',
        'node_modules/domready/ready.js' : 'domready'
      }
    },
    [...]
```
