### PR TITLE
fix: allow module files with // comments at the end

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var os = require('os');
 
 var BRIDGE_FILE_PATH = path.normalize(__dirname + '/../client/commonjs_bridge.js');
 
@@ -27,7 +28,7 @@ var createPreprocesor = function(logger) {
     var output =
       'window.__cjs_module__ = window.__cjs_module__ || {};' +
       'window.__cjs_module__["' + file.originalPath + '"] = function(require, module, exports) {' +
-        content +
+        content + os.EOL +
       '}';
 
     done(output);


### PR DESCRIPTION
This plugin wraps each module's content in a function call and does so without new lines (to preserve line numbers). But this mechanism will fail if module content ends with `// some comment` as it will result in `// some comment }` in a wrapped file, breaking the wrapping function.

The solution is to use a line break (OS-dependent) before the closing wrapping bracket. This shouldn't mess up line numbers as we are talking about the end of the original file here.
