### PR TITLE
fix: allow cycles in module dependencies

### DIFF
--- a/client/commonjs_bridge.js
+++ b/client/commonjs_bridge.js
@@ -21,8 +21,8 @@
         var module = cachedModules[dependency];
         if (module === undefined) {
             module = { exports: {} };
-            moduleFn(requireFn(dependency), module, module.exports);
             cachedModules[dependency] = module;
+            moduleFn(requireFn(dependency), module, module.exports);
         }
         return module.exports;
     };


### PR DESCRIPTION
Although hardly a good practice it might happen that we can have
cycles in module dependencies. Node.js is handling this situation
as described here: http://nodejs.org/api/modules.html#modules_cycles
The simple fix from this commit allows similar behavior.

On the project I'm playing with I've bumped into such situation that
was handled correctly by a module loader we are using but failed 
with stack overflow while using this plugin.
