### PR TITLE
feat: resolve depndencies on modules from a configured root

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ module.exports = function(config) {
   });
 };
 ```
+Additionally you can specify a root folder (relative to project's directory) which is used to look for required modules:
+```
+commonjsPreprocessor: {
+  modulesRoot: '/'  
+}
+```
+When not specified the root folder default to `node_modules`.
 
 For an example project, check out Karma's [client tests](https://github.com/karma-runner/karma/tree/master/test/client).
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,7 @@ var path = require('path');
 var os = require('os');
 
 var BRIDGE_FILE_PATH = path.normalize(__dirname + '/../client/commonjs_bridge.js');
+var DEFAULT_MODULES_ROOT_PATH = path.normalize(__dirname + '/../..');  //should point to node_modules
 
 var initCommonJS = function(/* config.files */ files) {
 
@@ -14,9 +15,17 @@ var initCommonJS = function(/* config.files */ files) {
   });
 };
 
+var calculateRootPathForModules = function(config) {
+   var modulesRootPath = config.modulesRoot ? path.join(__dirname, '/../../..', config.modulesRoot) : DEFAULT_MODULES_ROOT_PATH;
+   return path.resolve(modulesRootPath);
+}
 
-var createPreprocesor = function(logger) {
+var createPreprocesor = function(logger, config) {
   var log = logger.create('preprocessor.commonjs');
+  var modulesRootIncluded = false;
+  var modulesRootPath = calculateRootPathForModules(config || {});
+
+  log.debug('Configured root path for modules "%s".', modulesRootPath);
 
   return function(content, file, done) {
     if (file.originalPath === BRIDGE_FILE_PATH) {
@@ -31,10 +40,16 @@ var createPreprocesor = function(logger) {
         content + os.EOL +
       '}';
 
+    // output root folder configuration if needed  
+    if (!modulesRootIncluded) {
+      output = 'window.__cjs_modules_root__ = "' + modulesRootPath + '";' + output;
+      modulesRootIncluded = true;
+    }
+
     done(output);
   };
 };
-
+createPreprocesor.$inject = ['logger', 'config.commonjsPreprocessor'];
 
 // PUBLISH DI MODULE
 module.exports = {

--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -6,7 +6,7 @@ for (var modulePath in window.__cjs_module__) {
 };
 
 function require(requiringFile, dependency) {
-    dependency = normalizePath(requiringFile, dependency);
+    dependency = normalizePath(requiringFile, dependency, window.__cjs_modules_root__ || '');
 
     // find module
     var moduleFn = window.__cjs_module__[dependency];
@@ -28,23 +28,32 @@ function requireFn(basepath) {
     };
 };
 
-function normalizePath(basePath, relativePath) {
+function normalizePath(basePath, relativePath, modulesRoot) {
+
     if (isFullPath(relativePath)) return relativePath;
     if (!isFullPath(basePath)) throw new Error("basePath should be full path, but was [" + basePath + "]");
+
+    var relativePathLeadingChar = relativePath.charAt(0);
 
     var baseComponents = basePath.split("/");
     var relativeComponents = relativePath.split("/");
     var nextComponent;
+    
+    if (relativePathLeadingChar != '.') {
+        //pre-append defined root if needed, that is, dependency path is not full and doesn't start with one of . .. 
+        baseComponents = modulesRoot.split('/').concat(relativeComponents);
+    } else {
+        //else the path is somehow relative to the current files
+        baseComponents.pop();     // remove file portion of basePath before starting
+        while (relativeComponents.length > 0) {
+            nextComponent = relativeComponents.shift();
 
-    baseComponents.pop();     // remove file portion of basePath before starting
-    while (relativeComponents.length > 0) {
-        nextComponent = relativeComponents.shift();
-
-        if (nextComponent === ".") continue;
-        else if (nextComponent === "..") baseComponents.pop();
-        else baseComponents.push(nextComponent);
+            if (nextComponent === ".") continue;
+            else if (nextComponent === "..") baseComponents.pop();
+            else baseComponents.push(nextComponent);
+        }
     }
-
+    
     var normalizedPath = baseComponents.join("/");
 
     if (normalizedPath.substr(normalizedPath.length - 3) !== ".js") {

--- a/test/commonjs_bridge.spec.js
+++ b/test/commonjs_bridge.spec.js
@@ -7,7 +7,7 @@ describe('client', function() {
 	it('should correctly resolve modules with circular dependencies issue #6', function(){
 
 		 window.__cjs_module__['/foo.js'] = function(require, module, exports) {
-		 	var bar = require('bar');
+		 	var bar = require('./bar');
 		 	exports.txt = 'foo';
 		 	exports.getText = function() {
 		 		return 'foo ' + bar.txt;
@@ -15,15 +15,15 @@ describe('client', function() {
 		 };
 
 		 window.__cjs_module__['/bar.js'] = function(require, module, exports) {
-		 	var foo = require('foo');
+		 	var foo = require('./foo');
 		 	exports.txt = 'bar';
 		 	exports.getText = function() {
 		 		return 'bar ' + foo.txt;
 		 	}
 		 };		
 
-		expect(require('/app.js', 'foo').getText()).toEqual('foo bar');
-		expect(require('/app.js', 'bar').getText()).toEqual('bar foo');
+		expect(require('/app.js', './foo').getText()).toEqual('foo bar');
+		expect(require('/app.js', './bar').getText()).toEqual('bar foo');
 	});
 
 	describe('path resolving and normalization', function(){
@@ -49,7 +49,7 @@ describe('client', function() {
 		});
 
 		it('should resolve paths without qualifiers as relative to a defined root', function(){
-			expect(normalizePath('/base/foo.js', 'bar')).toEqual('/base/bar.js');
+			expect(normalizePath('/base/foo.js', 'bar', '/my/root')).toEqual('/my/root/bar.js');
 		});
 
 	});


### PR DESCRIPTION
This commit is a first shoot at resolving non-relative and non-absolute path from a configured "root folder" (defaulting to `node_modules`). It covers part of the node.js resolution module described in the "File Modules" section of http://nodejs.org/api/modules.html#modules_folders_as_modules

> Without a leading '/' or './' to indicate a file, the module is either a "core module" or is loaded from a node_modules folder.
