### PR TITLE
fix: allow processing non-js files

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -34,7 +34,7 @@ var createPreprocesor = function(logger, config, basePath) {
     var output =
       'window.__cjs_modules_root__ = "' + modulesRootPath + '";' +
       'window.__cjs_module__ = window.__cjs_module__ || {};' +
-      'window.__cjs_module__["' + file.originalPath + '"] = function(require, module, exports) {' +
+      'window.__cjs_module__["' + file.path + '"] = function(require, module, exports) {' +
       content + os.EOL +
       '}';
 


### PR DESCRIPTION
Before this change the plugin assumed that all CJS files are available under their original names, which is making it difficult to use with files compiled to JS from other languages (Coffee etc.). Coffee processor is changing a file name (https://github.com/karma-runner/karma-coffee-preprocessor/blob/master/index.js#L14) but CJS plugin was "blind" to those changes.

I'm not sure if this is the best fix and I can think of different approaches so would be grateful for a review. Also not fully aware of other consequences of changing a file name like this on other parts of Karma pipeline (caching etc.) so review is even more welcomed :-)
