### PR TITLE
refactor: check required global variables only once

### DIFF
--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -1,14 +1,6 @@
 var cachedModules = {};
 
-// load all modules
-for (var modulePath in window.__cjs_module__) {
-    require(modulePath, modulePath);
-}
-
 function require(requiringFile, dependency) {
-
-    if (window.__cjs_module__ === undefined) throw new Error("Could not find any modules. Did you remember to set 'preprocessors' in your Karma config?");
-    if (window.__cjs_modules_root__ === undefined) throw new Error("Could not find CommonJS module root path. Please report this issue to the karma-commonjs project.");
 
     var dependencyPaths = getDependencyPathCandidates(requiringFile, dependency, window.__cjs_modules_root__);
     var dependencyPath;

--- a/src/commonjs_bridge.wrapper
+++ b/src/commonjs_bridge.wrapper
@@ -2,6 +2,14 @@
 (function() {
     "use strict";
 
+     if (window.__cjs_module__ === undefined) throw new Error("Could not find any modules. Did you remember to set 'preprocessors' in your Karma config?");
+     if (window.__cjs_modules_root__ === undefined) throw new Error("Could not find CommonJS module root path. Please report this issue to the karma-commonjs project.");
+
 	%CONTENT%
+
+	// load all modules
+    for (var modulePath in window.__cjs_module__) {
+        require(modulePath, modulePath);
+    }
 
 })(window);


### PR DESCRIPTION
Moving checks to a wrapper in order to:
- avoid executing them on each call to `require`
- don't execute "load all modules" logic under tests
