### PR TITLE
feat: add support for the 'main' attribute from package.json

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -25,11 +25,16 @@ var createPreprocesor = function(logger, config, basePath) {
   log.debug('Configured root path for modules "%s".', modulesRootPath);
 
   return function(content, file, done) {
+
     if (file.originalPath === BRIDGE_FILE_PATH) {
       return done(content);
     }
 
     log.debug('Processing "%s".', file.originalPath);
+
+    if (path.basename(file.originalPath) === 'package.json') {
+      return done('window.__cjs_module__["' + file.path + '"] = ' + content + ';' + os.EOL);
+    }
 
     var output =
       'window.__cjs_modules_root__ = "' + modulesRootPath + '";' +

--- a/src/commonjs_bridge.wrapper
+++ b/src/commonjs_bridge.wrapper
@@ -7,9 +7,11 @@
 
 	%CONTENT%
 
-	// load all modules
+	// load all modules, skip package.json
     for (var modulePath in window.__cjs_module__) {
-        require(modulePath, modulePath);
+        if (modulePath.indexOf('package.json', -12) === -1) {
+            require(modulePath, modulePath);
+        }
     }
 
 })(window);

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -29,15 +29,15 @@ describe('Tests for various utility functions', function () {
   describe('normalize path', function () {
 
     it('should normalize relative path - happy path scenarios', function () {
-      expect(normalizeRelativePath('/foo/bar/baz/file.js', 'rel')).toEqual('/foo/bar/baz/rel');
-      expect(normalizeRelativePath('/foo/bar/baz/file.js', './rel')).toEqual('/foo/bar/baz/rel');
-      expect(normalizeRelativePath('/foo/bar/baz/file.js', '../../rel')).toEqual('/foo/rel');
-      expect(normalizeRelativePath('/foo/bar/baz/file.js', '../../bar/rel')).toEqual('/foo/bar/rel');
+      expect(normalizePath('/foo/bar/baz/file.js', 'rel')).toEqual('/foo/bar/baz/rel');
+      expect(normalizePath('/foo/bar/baz/file.js', './rel')).toEqual('/foo/bar/baz/rel');
+      expect(normalizePath('/foo/bar/baz/file.js', '../../rel')).toEqual('/foo/rel');
+      expect(normalizePath('/foo/bar/baz/file.js', '../../bar/rel')).toEqual('/foo/bar/rel');
     });
 
     //TODO(pk): not sure it is the "right" thing to do, but this test documents how the code works today
     it('should handle corner cases without throwing exceptions', function () {
-      expect(normalizeRelativePath('/foo/file.js', '../../../../rel')).toEqual('rel');
+      expect(normalizePath('/foo/file.js', '../../../../rel')).toEqual('rel');
     });
   });
 


### PR DESCRIPTION
Here is a set of more radical changes to the plugin in order to support the `main` attribute from the package.json. This is one of the last changes leading to the more-or-less complete support of node's loading algorithm for modules.

Fixes #16
