### PR TITLE
feat: load from the node_modules folder hierarchy

### DIFF
--- a/test/commonjs_bridge.spec.js
+++ b/test/commonjs_bridge.spec.js
@@ -33,16 +33,27 @@ describe('client', function() {
       });
     });
 
-    describe('resolve from node_modules', function () {
+    describe('resolve from node_modules and configured modules root', function () {
 
-      beforeEach(function () {
+      it('should resolve from the node_modules folder', function () {
+        window.__cjs_module__['/folder/node_modules/mymodule/foo.js'] = function(require, module, exports) {
+          exports.foo = true;
+        };
+        expect(require('/folder/bar.js', 'mymodule/foo').foo).toBeTruthy();
+      });
+
+      it('should resolve from the node_modules parent folder', function () {
+        window.__cjs_module__['/folder/node_modules/mymodule/foo.js'] = function(require, module, exports) {
+          exports.foo = true;
+        };
+        expect(require('/folder/subfolder/subsubfolder/bar.js', 'mymodule/foo').foo).toBeTruthy();
+      });
+
+      it('should resolve from the configured modules root', function () {
         window.__cjs_modules_root__ = '/root/node_modules';
         window.__cjs_module__['/root/node_modules/mymodule/foo.js'] = function(require, module, exports) {
           exports.foo = true;
         };
-      });
-
-      it('should resolve node_modules dependencies', function () {
         expect(require('/folder/bar.js', 'mymodule/foo').foo).toBeTruthy();
         expect(require('/folder/bar.js', 'mymodule/foo.js').foo).toBeTruthy();
       });


### PR DESCRIPTION
Fixes #21

This is the last step in supporting node's algorithm for loading modules. With this change we are going to look into the `node_modules` subfolder of a requiring file and traverse folders hierarchy upwards till a required file is found. I'm going to keep the "root folder" setting for now as it might be used to override certain modules in testing, for example.

This commit concludes several-months effort of making karma's load algorithm as close to the node's one as possible. The only remaining part is dealing with native modules but I don't think this is something we want to support. At least personally I don't have use-case for it.

There are probably corner cases not covered and the implementation could be better but well, we will deal with those issues as they surface.
