### PR TITLE
Fixes bug with loading npm modules

### DIFF
--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -2,10 +2,28 @@ var cachedModules = {};
 
 function loadPaths(paths, existingfiles) {
   for (var i=0; i<paths.length; i++) {
+    paths[i] = normalizeFilePath(paths[i]);
     if (existingfiles[paths[i]]) {
       return {module: existingfiles[paths[i]], path: paths[i]};
     }
   }
+}
+
+// normalizes this: /home/test/../dev/././proj/file.js
+// to this        : /home/dev/proj/file.js
+function normalizeFilePath(path){
+  var components = path.split('/');
+  var nextComponent, result = [];
+
+  while (components.length > 0) {
+    nextComponent = components.shift();
+
+    if (nextComponent === '.') continue;
+    if (nextComponent === '..') result.pop();
+    else result.push(nextComponent);
+  }
+
+  return result.join("/");
 }
 
 function loadAsFile(dependency, existingfiles) {


### PR DESCRIPTION
Fixes bug with loading npm modules if relative path is used in package.json.
For example see this part of package.json:
{ 
...
"main": "./moment.js",
... 
}

commonjs bridge will try to match it with loaded file in the following line:
if (existingfiles[paths[i]]) {
and fail since paths[i] will be smth like 
basepath/node_modules/moment/moment/./moment.js 
but in existing files it will be 
basepath/node_modules/moment/moment/moment.js
