### PR TITLE
Add ability to require any file extension 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,38 @@ module.exports = function(config) {
 
     preprocessors: {
       '**/*.js': ['commonjs']
-    }
+    },
+
   });
+
+
 };
 ```
-Additionally you can specify a root folder (relative to project's directory) which is used to look for required modules:
+
+### Additional options
+
+
+**modulesRoot**
+
+You can specify a root folder (relative to project's directory) which is used to look for required modules:
 ```
 commonjsPreprocessor: {
-  modulesRoot: 'some_folder'  
+  modulesRoot: 'some_folder'
 }
 ```
 When not specified the root folder default to the `karma.basePath/node_modules` configuration option.
+
+
+**extensions**
+
+commonjsPreprocessor: {
+  fileExtensions: ['.some.ext']
+}
+
+You can add an array of extension types that are required in your source files. This is useful when using other
+preprocessors that act on files with other extensions types like `.coffee` or `.jsx`.
+
+The default extensions that the preprocessor includes are `.js` and `.json`
 
 For an example project, check out Karma's [client tests](https://github.com/karma-runner/karma/tree/master/test/client).
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ When not specified the root folder default to the `karma.basePath/node_modules` 
 
 **extensions**
 
+```
 commonjsPreprocessor: {
   fileExtensions: ['.some.ext']
 }
-
+```
 You can add an array of extension types that are required in your source files. This is useful when using other
 preprocessors that act on files with other extensions types like `.coffee` or `.jsx`.
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,7 +4,6 @@ var os = require('os');
 var BRIDGE_FILE_PATH = path.normalize(__dirname + '/../client/commonjs_bridge.js');
 
 var initCommonJS = function(/* config.files */ files) {
-
   // Include the file that resolves all the dependencies on the client.
   files.push({
     pattern: BRIDGE_FILE_PATH,
@@ -14,9 +13,14 @@ var initCommonJS = function(/* config.files */ files) {
   });
 };
 
-var createPreprocesor = function(logger, config, basePath) {
+var createPreprocesor = function(logger, config, basePath,helper) {
   var log = logger.create('preprocessor.commonjs');
   var modulesRootPath = path.resolve(config && config.modulesRoot ? config.modulesRoot : path.join(basePath, 'node_modules'));
+
+  var fileExtensions = ['.js','.json'].concat(config.fileExtensions || []);
+  var extensions;
+  var orginalPathExt;
+
   //normalize root path on Windows
   if (process.platform === 'win32') {
     modulesRootPath = modulesRootPath.replace(/\\/g, '/');
@@ -32,8 +36,17 @@ var createPreprocesor = function(logger, config, basePath) {
 
     log.debug('Processing "%s".', file.originalPath);
 
+    orginalPathExt = path.extname(file.originalPath);
+
+    extensions = '';
+    if (fileExtensions.indexOf(orginalPathExt) > -1) {
+      extensions =
+        'window.__cjs_file_extensions__ = window.__cjs_file_extensions__ || [".js",".json"];' +
+        'if (window.__cjs_file_extensions__.indexOf("'+orginalPathExt +'") === -1){window.__cjs_file_extensions__.push("' + orginalPathExt + '");}';
+    }
+
     if (path.extname(file.originalPath) === '.json') {
-      return done('window.__cjs_module__["' + file.path + '"] = ' + content + ';' + os.EOL);
+      return done(extensions + 'window.__cjs_module__["' + file.path + '"] = ' + content + ';' + os.EOL);
     }
 
     var output =
@@ -43,10 +56,10 @@ var createPreprocesor = function(logger, config, basePath) {
       content + os.EOL +
       '}';
 
-    done(output);
+    done(extensions + output);
   };
 };
-createPreprocesor.$inject = ['logger', 'config.commonjsPreprocessor', 'config.basePath'];
+createPreprocesor.$inject = ['logger', 'config.commonjsPreprocessor', 'config.basePath', 'helper'];
 
 // PUBLISH DI MODULE
 module.exports = {

--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -9,7 +9,13 @@ function loadPaths(paths, existingfiles) {
 }
 
 function loadAsFile(dependency, existingfiles) {
-  return loadPaths([dependency, dependency + '.js', dependency + '.json'], existingfiles);
+  var extensions = ['', '.js', '.json'];
+
+  var paths = extensions.map(function(ext) {
+    return dependency + ext;
+  });
+
+  return loadPaths(paths, existingfiles);
 }
 
 function loadAsDirectory(dependency, existingfiles) {

--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -9,12 +9,10 @@ function loadPaths(paths, existingfiles) {
 }
 
 function loadAsFile(dependency, existingfiles) {
-  var extensions = ['', '.js', '.json'];
-
+  var extensions = [''].concat(window.__cjs_file_extensions__);
   var paths = extensions.map(function(ext) {
     return dependency + ext;
   });
-
   return loadPaths(paths, existingfiles);
 }
 

--- a/test/commonjs_bridge.spec.js
+++ b/test/commonjs_bridge.spec.js
@@ -5,6 +5,7 @@ describe('client', function() {
     beforeEach(function(){
       window.__cjs_module__ = {};
       window.__cjs_modules_root__ = '/root';
+      window.__cjs_file_extensions__ = ['.js', '.json'];
       cachedModules = {};
     });
 
@@ -45,6 +46,25 @@ describe('client', function() {
       it('should resolve dependencies to JS before resolving JSON', function () {
         window.__cjs_module__['/folder/foo.json'] = {foo: false};
         expect(require('/folder/bar.js', './foo').foo).toBeTruthy();
+      });
+
+      describe('with any file extension', function() {
+
+        beforeEach(function() {
+          window.__cjs_file_extensions__ = ['.js', '.json', '.cljs', '.jsx'];
+        });
+
+        it('should resolve a non JS or JSON file extension', function() {
+          window.__cjs_module__['/folder/baz.cljs'] = {baz: 'baz'};
+          expect(require('/folder/bar.js', '/folder/baz.cljs').baz).toEqual('baz');
+          expect(require('/folder/bar.js', '/folder/baz').baz).toEqual('baz');
+        });
+
+        it('should resolve dependencies to JS and JSON before other file extensions', function() {
+          window.__cjs_module__['/folder/boo.json'] = {boo: true};
+          window.__cjs_module__['/folder/boo.jsx'] = {boo: false};
+          expect(require('/folder/bar.js', './boo').boo).toBeTruthy();
+        });
       });
     });
 


### PR DESCRIPTION
Adds a configuration property, `fileExtensions`, that allows `require` to source files with file extensions other than `.js` or `.json`.  This is useful when using  karma preprocessors that may not change the file path names but do generate valid JS.
