### PR TITLE
fix: add global variable to mock node's global object

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -40,6 +40,7 @@ var createPreprocesor = function(logger, config, basePath) {
       'window.__cjs_modules_root__ = "' + modulesRootPath + '";' +
       'window.__cjs_module__ = window.__cjs_module__ || {};' +
       'window.__cjs_module__["' + file.path + '"] = function(require, module, exports, __dirname, __filename) {' +
+      'var global = window;\n' +
       content + os.EOL +
       '}';
 


### PR DESCRIPTION
This fixes issues with some node.js packages (like lodash v3) which use global object.