### PR TITLE
add fallback for require that using aliases

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -37,6 +37,7 @@ var createPreprocesor = function(logger, config, basePath) {
     }
 
     var output =
+      'window.__karma_config__ = ' + JSON.stringify(config) + ';' +
       'window.__cjs_modules_root__ = "' + modulesRootPath + '";' +
       'window.__cjs_module__ = window.__cjs_module__ || {};' +
       'window.__cjs_module__["' + file.path + '"] = function(require, module, exports, __dirname, __filename) {' +

--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -36,10 +36,30 @@ function runModule(moduleFn, dependencyPath, requiringFilePath) {
   return module.exports;
 }
 
+function normalizeRelativePath(parentPath, path) {
+    parentPath = parentPath.charAt(parentPath.length - 1) === '/' ? parentPath.substr(0, parentPath.length - 1) : parentPath;
+    if (parentPath && parentPath.length > 0 && path && path.length > 0) {
+        while (path.charAt(0) === '.') {
+            if (path.indexOf('../') === 0) {
+                path = path.substr(path.indexOf('/') + 1);
+                parentPath = parentPath.substr(0, parentPath.lastIndexOf('/'));
+            } else if (path.indexOf('./') === 0) {
+                path = path.substr(path.indexOf('/') + 1);
+            }
+        }
+        return parentPath + (path.charAt(0) === '/' ? path : '/' + path);
+    }
+}
+
 function require(requiringFile, dependency) {
 
   var resolvedModule, normalizedDepPath;
   var requiringPathEls;
+  
+  if (window.__karma_config__ && window.__karma_config__.alias && window.__karma_config__.alias[dependency]) {
+    normalizedDepPath = normalizeRelativePath(window.__cjs_modules_root__, window.__karma_config__.alias[dependency]);
+    resolvedModule = loadAsFileOrDirectory(normalizedDepPath, window.__cjs_module__);
+  }
 
   if (!isFullPath(requiringFile)) throw new Error("requiringFile path should be full path, but was [" + requiringFile + "]");
 


### PR DESCRIPTION
I added a fallback in module resolution, giving the possibility to add an alias for a module.
In the karma.conf.js, aliases can be specified like below:

```
module.exports = function (config) {
  config.set({
    ...
    commonjsPreprocessor: {
      ...
      alias: {
        'module_a': '../node_modules/common_module_a/lib/common_module.js',
        'module_b': '../node_modules/common_module_b/lib/common_module.js'
      }
    }
    ...
  });
};
```

In this way `require('module_a')` is resolved to `'../node_modules/common_module_a/lib/common_module.js'`

This resolves the issue #52
