### PR TITLE
fix(Windows): load from node_modules on Windows

### DIFF
--- a/src/commonjs_bridge.js
+++ b/src/commonjs_bridge.js
@@ -46,12 +46,12 @@ function require(requiringFile, dependency) {
   if (isNpmModulePath(dependency)) {
 
     requiringPathEls = requiringFile.split('/');
-    requiringPathEls.pop(); //cut of file part
-    requiringPathEls.shift(); //cut of initial part coming from /
+    requiringPathEls.pop(); //cut off file part
+    var drive = requiringPathEls.shift(); //cut off part coming before first / ('c:' on Windows, '' on Unix)
 
     //load from node_modules, traversing folders hierarchy up
     while (requiringPathEls.length && !resolvedModule) {
-      normalizedDepPath = normalizePath('/' +requiringPathEls.join('/') + '/node_modules/file.js', dependency);
+      normalizedDepPath = normalizePath(drive + '/' +requiringPathEls.join('/') + '/node_modules/file.js', dependency);
       resolvedModule = loadAsFileOrDirectory(normalizedDepPath, window.__cjs_module__);
       requiringPathEls.pop();
     }

--- a/test/commonjs_bridge.spec.js
+++ b/test/commonjs_bridge.spec.js
@@ -73,6 +73,13 @@ describe('client', function() {
         expect(require('/folder/bar.js', 'mymodule/foo.js').foo).toBeTruthy();
       });
 
+      it('should resolve on Windows', function() {
+        window.__cjs_module__['c:/folder/node_modules/mymodule/foo.js'] = function(require, module, exports) {
+          exports.foo = true;
+        };
+        expect(require('c:/folder/bar.js', 'mymodule/foo').foo).toBeTruthy();
+      });
+
     });
 
     describe('resolve from folders', function () {


### PR DESCRIPTION
In karma-commonjs 1.0.0, `require("foo");` doesn't work on Windows due to the drive letter being stripped off. This patch preserves the drive letter, which fixes the problem.
